### PR TITLE
Interpolate distance nodes

### DIFF
--- a/sarbor/segmentations.py
+++ b/sarbor/segmentations.py
@@ -259,8 +259,8 @@ class SegmentationSource:
             self.distances[node_bounds] = np.minimum(
                 self.distances[node_bounds], dist_block
             )
-            if interpolate_dist_nodes > 0:
-                for neighbor in node.get_neighbors():
+            if interpolate_dist_nodes > 0 and node.children is not None:
+                for neighbor in node.children:
                     for k in range(1, interpolate_dist_nodes + 1):
                         linear_step = neighbor.value.center * k / (
                             interpolate_dist_nodes + 1

--- a/sarbor/segmentations.py
+++ b/sarbor/segmentations.py
@@ -241,7 +241,12 @@ class SegmentationSource:
         ).reshape(1, 1, dimensions[2])
         return (x + y + z) ** (0.5) / np.sum((half_dim * resolution) ** 2) ** (0.5)
 
-    def create_octrees_from_nodes(self, nodes: Iterable[Node], sphere: bool = False):
+    def create_octrees_from_nodes(
+        self,
+        nodes: Iterable[Node],
+        sphere: bool = False,
+        interpolate_dist_nodes: int = 0,
+    ):
         dist_block = self._dist_block(self.fov_shape_voxels, self.voxel_resolution)
         if sphere:
             dist_block[np.logical_not(self.sphere)] = float("inf")
@@ -254,6 +259,18 @@ class SegmentationSource:
             self.distances[node_bounds] = np.minimum(
                 self.distances[node_bounds], dist_block
             )
+            if interpolate_dist_nodes > 0:
+                for neighbor in node.get_neighbors():
+                    for k in range(1, interpolate_dist_nodes + 1):
+                        linear_step = neighbor.value.center * k / (
+                            interpolate_dist_nodes + 1
+                        ) + node.value.center * (interpolate_dist_nodes - k) / (
+                            interpolate_dist_nodes + 1
+                        )
+                        mid_bounds = self.transform_bounds(self.get_roi(linear_step))
+                        self.distances[mid_bounds] = np.minimum(
+                            self.distances[mid_bounds], dist_block
+                        )
 
     def save_data(self, folder_path: Path):
         """

--- a/sarbor/skeletons.py
+++ b/sarbor/skeletons.py
@@ -635,7 +635,7 @@ class Skeleton:
         for node in self.get_nodes():
             if node.parent is not None:
                 nid_score_map[(node.key, node.parent_key)] = (
-                    (tuple((node.value.center), tuple(node.parent.value.center))),
+                    (tuple(node.value.center), tuple(node.parent.value.center)),
                     self.get_connection(node, node.parent),
                 )
         return nid_score_map

--- a/sarbor/skeletons.py
+++ b/sarbor/skeletons.py
@@ -972,7 +972,7 @@ class Skeleton:
     def get_closest_node(self, location: np.ndarray):
         closest = None
         dist = 0
-        for node in self.nodes:
+        for nid, node in self.nodes.items():
             if closest is None or np.linalg.norm(node.value.center - location) < dist:
                 closest = node
                 dist = np.linalg.norm(node.value.center)

--- a/sarbor/skeletons.py
+++ b/sarbor/skeletons.py
@@ -969,3 +969,11 @@ class Skeleton:
         )
         return new_skeleton
 
+    def get_closest_node(self, location: np.ndarray):
+        closest = None
+        dist = 0
+        for node in self.nodes:
+            if closest is None or np.linalg.norm(node.value.center - location) < dist:
+                closest = node
+                dist = np.linalg.norm(node.value.center)
+

--- a/sarbor/skeletons.py
+++ b/sarbor/skeletons.py
@@ -635,7 +635,7 @@ class Skeleton:
         for node in self.get_nodes():
             if node.parent is not None:
                 nid_score_map[(node.key, node.parent_key)] = (
-                    tuple((node.value.center + node.parent.value.center) // 2),
+                    (tuple((node.value.center), tuple(node.parent.value.center))),
                     self.get_connection(node, node.parent),
                 )
         return nid_score_map

--- a/sarbor/skeletons.py
+++ b/sarbor/skeletons.py
@@ -635,7 +635,7 @@ class Skeleton:
         for node in self.get_nodes():
             if node.parent is not None:
                 nid_score_map[(node.key, node.parent_key)] = (
-                    (tuple(node.value.center), tuple(node.parent.value.center)),
+                    (node.value.center, node.parent.value.center),
                     self.get_connection(node, node.parent),
                 )
         return nid_score_map

--- a/sarbor/skeletons.py
+++ b/sarbor/skeletons.py
@@ -976,4 +976,5 @@ class Skeleton:
             if closest is None or np.linalg.norm(node.value.center - location) < dist:
                 closest = node
                 dist = np.linalg.norm(node.value.center)
+        return closest
 


### PR DESCRIPTION
Allow for placing virtual nodes for the purpose of having a more cylindrical distance heuristic and accounting for sparse node placement